### PR TITLE
(SIMP-4250) Allow user to define system_table entries in hiera

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jan 8 2018 Rurik Yla-Onnenvuori <rurik.ylae-onnenvuori@baloise.com> - 0.0.4-0
+- Add support for defining system table entries in hiera
+
 * Fri Aug 18 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 0.0.3-0
 - Update concat version in metadata.json
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ incron::users:
   - bar
 ```
 
+New system table entries can be added to `/etc/incron.d/` directory with the `incron::system_table` defined type, or
+with the `incron::system_table` hash in hiera. The following example adds two new system table entries to `/etc/incron.d/` directory:
+
+```yaml
+::incron::system_table:
+  allowrw:
+    path: '/data/'
+    command: '/usr/bin/chmod -R 774 $@/$#'
+    mask: ['IN_CREATE']
+  deletelog:
+    path: '/var/run/daemon'
+    command: '/usr/bin/rm /var/log/daemon.log'
+    mask: ['IN_DELETE']
+```
 
 ## Reference
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,7 +1,0 @@
-# Drop all Requires, Obsoletes, and Provides statements in here
-Requires: pupmod-puppetlabs-concat < 4.0.0
-Requires: pupmod-puppetlabs-concat >= 2.2.0
-Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
-Requires: pupmod-puppetlabs-stdlib >= 4.13.1-0
-Requires: pupmod-simp-simplib < 4.0.0-0
-Requires: pupmod-simp-simplib >= 3.1.0-0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,8 +6,13 @@
 #   incron::user.
 #
 class incron (
-  Array[String] $users = []
+  Array[String] $users = [],
+  Hash $system_table   = {},
 ) {
+
+  $system_table.each |$name, $values| {
+    ::incron::system_table { $name: * => $values }
+  }
 
   $users.each |String $user| {
     ::incron::user { $user: }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-incron",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet module for managing incron",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-incron",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet module for managing incron",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -32,6 +32,16 @@ describe 'incron' do
           it { is_expected.to create_incron__user('bar') }
         end
 
+        context 'with a system_table parameter' do
+          let(:params) {{
+            :system_table => {
+              :allowrw   => {:path => '/data/', :command => '/usr/bin/chmod -R 774 $@/$#', :mask => ['IN_CREATE']},
+              :deletelog => {:path => '/var/run/', :command => '/usr/bin/rm /var/log/daemon.log', :mask => ['IN_DELETE']}
+            }
+          }}
+          it { is_expected.to create_incron__system_table('allowrw') }
+          it { is_expected.to create_incron__system_table('deletelog') }
+        end
       end
     end
   end


### PR DESCRIPTION
User should be able to define new system table entries in hiera.

Example:
```
::incron::system_table:
  cleantmp:
        path: '/tmp'
        command: '/usr/bin/rm /tmp/*'
        mask: ['IN_CREATE']
  allowrw:
        path: '/data/'
        command: '/usr/bin/chmod -R 777 /data/'
        mask: ['IN_CREATE']
```