### PR TITLE
Remove pupmod-simp-simplib from the dependencies

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,6 @@
 fixtures:
   repositories:
     stdlib:  "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    simplib: "https://github.com/simp/pupmod-simp-simplib.git"
     concat:
       # master is at 4.0.1, but we are bound to < 4.0.0 in our metadata.json
       repo: https://github.com/simp/puppetlabs-concat

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
-* Mon Jan 8 2018 Rurik Yla-Onnenvuori <rurik.ylae-onnenvuori@baloise.com> - 0.0.4-0
+* Mon Jan 8 2018 Rurik Yla-Onnenvuori <rurik.ylae-onnenvuori@baloise.com> - 0.1.0-0
 - Add support for defining system table entries in hiera
+- Remove dependency to simplib
 
 * Fri Aug 18 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 0.0.3-0
 - Update concat version in metadata.json

--- a/manifests/system_table.pp
+++ b/manifests/system_table.pp
@@ -19,27 +19,32 @@ define incron::system_table (
 ) {
   include '::incron'
 
-  validate_re_array($mask,[
-    'IN_ACCESS',
-    'IN_ALL_EVENTS',
-    'IN_ATTRIB',
-    'IN_CLOSE',
-    'IN_CLOSE_NOWRITE',
-    'IN_CLOSE_WRITE',
-    'IN_CREATE',
-    'IN_DELETE',
-    'IN_DELETE_SELF',
-    'IN_DONT_FOLLOW',
-    'IN_MODIFY',
-    'IN_MOVE',
-    'IN_MOVED_FROM',
-    'IN_MOVED_TO',
-    'IN_MOVE_SELF',
-    'IN_NO_LOOP',
-    'IN_ONESHOT',
-    'IN_ONLYDIR',
-    'IN_OPEN'
-  ])
+  $mask.each |String $_tmp_mask| {
+    if ! ($_tmp_mask in
+    [
+      'IN_ACCESS',
+      'IN_ALL_EVENTS',
+      'IN_ATTRIB',
+      'IN_CLOSE',
+      'IN_CLOSE_NOWRITE',
+      'IN_CLOSE_WRITE',
+      'IN_CREATE',
+      'IN_DELETE',
+      'IN_DELETE_SELF',
+      'IN_DONT_FOLLOW',
+      'IN_MODIFY',
+      'IN_MOVE',
+      'IN_MOVED_FROM',
+      'IN_MOVED_TO',
+      'IN_MOVE_SELF',
+      'IN_NO_LOOP',
+      'IN_ONESHOT',
+      'IN_ONLYDIR',
+      'IN_OPEN'
+    ]) {
+      fail("${_tmp_mask} is not a valid mask")
+    }
+  }
 
   $_mask = join($mask,',')
   if $custom_content {

--- a/metadata.json
+++ b/metadata.json
@@ -12,10 +12,6 @@
   ],
   "dependencies": [
     {
-      "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
-    },
-    {
       "name": "puppetlabs/concat",
       "version_requirement": ">= 2.2.0 < 4.0.0"
     },


### PR DESCRIPTION
Replace the function `validate_re_array` (from the simplib) with a simpler check and remove the dependency from the incron module.

Reason behind this is that some functions from the simplib are interfering with puppetlabs-stdlib - `validate_integer()` for example. As the simplib is not strictly needed here, I propose removing it completely. 
  