### PR TITLE
(SIMP-4652) Align with RPM defaults

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -190,6 +190,7 @@ default:
   variables:
     PUPPET_VERSION: '4.10'
   script:
+    - bundle exec rake spec_clean
     - bundle exec rake beaker:suites[default]
 
 fips:
@@ -202,4 +203,5 @@ fips:
     PUPPET_VERSION: '4.10'
     BEAKER_fips: 'yes'
   script:
+    - bundle exec rake spec_clean
     - bundle exec rake beaker:suites[default]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Tue Jun 19 2018 Nick Miller <nick.miller@onyxpoint.com> - 0.3.0-0
+- Stop managing the systemd unit file, because deviating from the RPM defaults
+  violates the STIG
+- Set /etc/incron.d to 0755, the RPM default
+
 * Fri May 04 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.3.0-0
 - Added a native type `incron_system_table` to allow for client side glob
   expansion on paths

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,1 +1,0 @@
-SIMP Team

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,18 +38,7 @@ class incron (
     ensure => 'directory',
     owner  => 'root',
     group  => 'root',
-    mode   => '0640'
-  }
-
-  # service installed with wrong permissions from rpm.
-  # If permissions not changed you get annoying error
-  # in system log.
-  if 'systemd' in $facts['init_systems'] {
-    file { '/usr/lib/systemd/system/incrond.service':
-      mode    => '0644',
-      require => Package['incron'],
-      before  => Service['incrond']
-    }
+    mode   => '0755'
   }
 
   service { 'incrond':

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,59 +1,41 @@
 require 'spec_helper'
 
 describe 'incron' do
-  context 'supported operating systems' do
-    on_supported_os.each do |os, os_facts|
-      context "on #{os}" do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      context 'with default parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('incron') }
+        it { is_expected.to create_incron__user('root') }
+        it { is_expected.to create_concat('/etc/incron.allow') }
+        it { is_expected.to create_file('/etc/incron.deny').with({:ensure => 'absent'}) }
+        it { is_expected.to create_package('incron').with({:ensure => 'installed'}) }
+        it { is_expected.to create_service('incrond').with({
+          :ensure     => 'running',
+          :enable     => true,
+          :hasstatus  => true,
+          :hasrestart => true
+        }) }
+      end
 
-        if os_facts[:operatingsystemmajrelease].to_s == '6'
-          let(:facts) do
-            os_facts.merge(init_systems: ['sysv'])
-          end
-        else
-          let(:facts) do
-            os_facts.merge(init_systems: ['systemd'])
-          end
-        end
+      context 'with a users parameter' do
+        let(:params) {{
+          :users => ['test','foo','bar']
+        }}
+        it { is_expected.to create_incron__user('test') }
+        it { is_expected.to create_incron__user('foo') }
+        it { is_expected.to create_incron__user('bar') }
+      end
 
-        context 'with default parameters' do
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_class('incron') }
-          it { is_expected.to create_incron__user('root') }
-          it { is_expected.to create_concat('/etc/incron.allow') }
-          it { is_expected.to create_file('/etc/incron.deny').with({:ensure => 'absent'}) }
-          it { is_expected.to create_package('incron').with({:ensure => 'installed'}) }
-          if os_facts[:operatingsystemmajrelease].to_s == '6'
-            it { is_expected.to_not create_file('/usr/lib/systemd/system/incrond.service')}
-          else
-            it { is_expected.to create_file('/usr/lib/systemd/system/incrond.service').with_mode('0644')}
-          end
-          it { is_expected.to create_service('incrond').with({
-            :ensure     => 'running',
-            :enable     => true,
-            :hasstatus  => true,
-            :hasrestart => true
-          }) }
-        end
-
-        context 'with a users parameter' do
-          let(:params) {{
-            :users => ['test','foo','bar']
-          }}
-          it { is_expected.to create_incron__user('test') }
-          it { is_expected.to create_incron__user('foo') }
-          it { is_expected.to create_incron__user('bar') }
-        end
-
-        context 'with a system_table parameter' do
-          let(:params) {{
-            :system_table => {
-              :allowrw   => {:path => '/data/', :command => '/usr/bin/chmod -R 774 $@/$#', :mask => ['IN_CREATE']},
-              :deletelog => {:path => '/var/run/', :command => '/usr/bin/rm /var/log/daemon.log', :mask => ['IN_DELETE']}
-            }
-          }}
-          it { is_expected.to create_incron__system_table('allowrw') }
-          it { is_expected.to create_incron__system_table('deletelog') }
-        end
+      context 'with a system_table parameter' do
+        let(:params) {{
+          :system_table => {
+            :allowrw   => {:path => '/data/', :command => '/usr/bin/chmod -R 774 $@/$#', :mask => ['IN_CREATE']},
+            :deletelog => {:path => '/var/run/', :command => '/usr/bin/rm /var/log/daemon.log', :mask => ['IN_DELETE']}
+          }
+        }}
+        it { is_expected.to create_incron__system_table('allowrw') }
+        it { is_expected.to create_incron__system_table('deletelog') }
       end
     end
   end


### PR DESCRIPTION
- Stop managing the systemd unit file, because deviating from the RPM
  defaults violates the STIG
- Set /etc/incron.d to 0755, the RPM default

SIMP-4652 #comment fix incron