### PR TITLE
(SIMP-6147) Improperly confined fact

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Tue Feb 26 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.4.1-0
+- Fixed a bug in the incrond_version fact in which an error message
+  was displayed during fact resolution, on systems for which incron
+  was not installed.
+
 * Sun Jan 20 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.4.0-0
 - Add the ability to set the 'max_open_files' ulimit
 - Add Incron::Mask Data Type denoting valid incron masks

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Description
 
-This module manages the incron packges, service, and /etc/incron.allow.
+This module manages the incron packages, service, and /etc/incron.allow.
 
 
 ### This is a SIMP module
@@ -95,7 +95,7 @@ SIMP Puppet modules are generally intended for use on Red Hat Enterprise Linux a
 
 ## Development
 
-Please read our [Contribution Guide] (http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide] (http://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 
 ### Acceptance tests

--- a/lib/facter/incrond_version.rb
+++ b/lib/facter/incrond_version.rb
@@ -2,7 +2,7 @@
 
 Facter.add('incrond_version') do
   incrond_cmd = Facter::Util::Resolution.which('incrond')
-  confine { File.executable?(incrond_cmd) }
+  confine { incrond_cmd && File.executable?(incrond_cmd) }
 
   setcode do
     require 'open3'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-incron",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet module for managing incron",
   "license": "Apache-2.0",

--- a/spec/unit/facter/incrond_version_spec.rb
+++ b/spec/unit/facter/incrond_version_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'open3'
+
+describe 'incrond_version' do
+
+  before :each do
+    Facter.clear
+  end
+
+  context 'incrond command exists' do
+    it 'returns the correct version of incrond when incrond is executable' do
+      Facter::Util::Resolution.expects(:which).with('incrond').returns('/usr/sbin/incrond')
+      File.expects(:executable?).with('/usr/sbin/incrond').returns(true)
+      # 3rd entry in returned array is a ProcessStatus object, but since we don't
+      # use it, not mocking its value
+      Open3.expects(:capture3).with('/usr/sbin/incrond', '--version').returns(['', "incrond 1.2.3\n", nil])
+      expect(Facter.fact(:incrond_version).value).to eq('1.2.3')
+    end
+
+    it 'returns nil when incrond is not executable' do
+      Facter::Util::Resolution.expects(:which).with('incrond').returns('/usr/sbin/incrond')
+      File.expects(:executable?).with('/usr/sbin/incrond').returns(false)
+      expect(Facter.fact(:incrond_version).value).to eq(nil)
+    end
+  end
+
+  context 'incrond command does not exist' do
+    it 'returns nil' do
+      Facter::Util::Resolution.expects(:which).with('incrond').returns(nil)
+      expect(Facter.fact(:incrond_version).value).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
- Fixed a bug in the incrond_version fact in which an error message
  was displayed during fact resolution, on systems for which incron
  was not installed.
- Fixed typos in README.md

SIMP-6147 #comment pupmod-simp-incron fact fix