### PR TITLE
(SIMP-6213) Use latest concat in tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,10 +3,6 @@ fixtures:
   repositories:
     stdlib:  https://github.com/puppetlabs/puppetlabs-stdlib.git
     simplib: https://github.com/simp/pupmod-simp-simplib
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat:  https://github.com/simp/puppetlabs-concat
   symlinks:
     incron: "#{source_dir}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 - Fixed a bug in the incrond_version fact in which an error message
   was displayed during fact resolution, on systems for which incron
   was not installed.
+- Expanded the upper limits of the concat and stdlib Puppet module versions
 
 * Sun Jan 20 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.4.0-0
 - Add the ability to set the 'max_open_files' ulimit

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ SIMP Puppet modules are generally intended for use on Red Hat Enterprise Linux a
 
 ## Development
 
-Please read our [Contribution Guide] (http://simp.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide] (https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 
 ### Acceptance tests

--- a/metadata.json
+++ b/metadata.json
@@ -13,11 +13,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.2.0 < 5.0.0"
+      "version_requirement": ">= 2.2.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "simp/simplib",


### PR DESCRIPTION
- Test with latest concat Puppet module instead of 4.1.1
- Expanded the upper limits of the concat and stdlib Puppet module versions

SIMP-6213 #comment pupmod-simp-incron