### PR TITLE
(SIMP-10040) incron Add Puppet 7 acceptance test

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,7 @@
 fixtures:
   repositories:
     stdlib:  https://github.com/puppetlabs/puppetlabs-stdlib.git
-    simplib: https://github.com/simp/pupmod-simp-simplib
-    concat:  https://github.com/simp/puppetlabs-concat
+    simplib: https://github.com/simp/pupmod-simp-simplib.git
+    concat:  https://github.com/simp/puppetlabs-concat.git
   symlinks:
     incron: "#{source_dir}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -393,3 +393,9 @@ pup6.pe-oel-fips:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
+
+pup7.x:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,default]'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -20,6 +20,10 @@ RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts
 
+  # Detect cases in which no examples are executed (e.g., nodeset does not
+  # have hosts with required roles)
+  c.fail_if_no_examples = true
+
   # Readable test descriptions
   c.formatter = :documentation
 


### PR DESCRIPTION
* Add a Puppet 7 acceptance test
* Made sure all fixture URLs end in '.git', as not all private
  GitHub mirrors allow shortened URLs
* Fail acceptance tests if no examples are executed.

[SIMP-9666] #comment pupmod-simp-incron acceptance tests configured
SIMP-10040 #close

[SIMP-9666]: https://simp-project.atlassian.net/browse/SIMP-9666