### PR TITLE
(SIMP-10204) Ensure testing with CentOS 8.4

### DIFF
--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -18,7 +18,7 @@ HOSTS:
     roles:
       - client
     platform:   el-8-x86_64
-    box:        centos/8
+    box:        generic/centos8
     hypervisor: <%= hypervisor %>
 
 CONFIG:

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -11,13 +11,8 @@ HOSTS:
       - server
       - default
     platform:   el-7-x86_64
-    box:        onyxpoint/oel-7-x86_64
+    box:        generic/oracle7
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
 
   oel8:
     roles:
@@ -25,11 +20,6 @@ HOSTS:
     platform:   el-8-x86_64
     box:        generic/oracle8
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -30,10 +30,6 @@ describe 'incron class' do
         "#{host.puppet[:environmentpath]}/production/modules/incron/lib/test"
       }
 
-      it 'should install the EPEL repo' do
-        install_package(host, 'epel-release')
-      end
-
       it 'should work with default values' do
         apply_manifest_on(host, manifest, catch_failures: true)
       end


### PR DESCRIPTION
- update the EL8 nodes in the acceptance tests
  to run with generic/centos8 to make sure they using
  CentOS 8.4
- update oel7 box to generic from onyxpoint.
- remove epel intall from nodeset and from test,
  it is automatically installed by linux_errata in beaker helpers.

SIMP-10204 #comment incron updated
SIMP-10224 #close