### PR TITLE
Add recurse parameter to the inicron.d directory so that it unmanaged…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri May 13 2022 Brian Schonecker <brian.schonecker@nfiindustries.com> - 0.6.1
+- Ensure that incron files are deleted when `purge` is `true`
+
 * Tue Jun 15 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.6.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ incron::users:
 ```
 
 New system table entries can be added to `/etc/incron.d/` directory with the `incron::system_table` defined type, or
-with the `incron::system_table` hash in hiera. The following example adds two new system table entries to `/etc/incron.d/` directory:
+with the `incron::system_table` hash in hiera. The following example adds two new system table entries to `/etc/incron.d/` 
+directory and removes unmanaged files: 
 
 ```yaml
+incron::purge: true
 incron::system_table:
   allowrw:
     path: '/data/'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,11 +59,12 @@ class incron (
   }
 
   file { '/etc/incron.d':
-    ensure => 'directory',
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0755',
-    purge  => $purge
+    ensure  => 'directory',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+    purge   => $purge,
+    recurse => $purge
   }
 
   init_ulimit { 'mod_open_files_incrond':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-incron",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet module for managing incron",
   "license": "Apache-2.0",


### PR DESCRIPTION
… files get deleted.

According to Puppet 5 documentation, the [file resource](https://puppet.com/docs/puppet/5.5/types/file.html#file-attribute-purge) needs recurse => true when purging a directory.

Puppet 7 documentation indicates the [same](https://puppet.com/docs/puppet/7/types/file.html#file-attribute-purge).