### PR TITLE
Fix system_table idempotency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Aug 25 2022 Brian Schonecker <brian.schonecker@nfiindustries.com> - 0.6.2
+- Prevent Puppet from purging files created with `incron::system_table`
+
 * Fri May 13 2022 Brian Schonecker <brian.schonecker@nfiindustries.com> - 0.6.1
 - Ensure that incron files are deleted when `purge` is `true`
 

--- a/manifests/system_table.pp
+++ b/manifests/system_table.pp
@@ -68,19 +68,18 @@ define incron::system_table (
   # custom type, otherwise Puppet will purge the /etc/incron.d directory of
   # all files and then the custom type will recreate them resulting in
   # a non-idempotent loop.
-  file { "/etc/incron.d/${name}":
-    ensure => file,
-  }
+  $_safe_name=simplib::safe_filename($name)
+  file { "/etc/incron.d/${_safe_name}": ensure => file }
 
   if $custom_content {
-    incron_system_table { $name:
+    incron_system_table { $_safe_name:
       ensure  => $_ensure,
       content => $custom_content,
       notify  => Class['incron::service']
     }
   }
   else {
-    incron_system_table { $name:
+    incron_system_table { $_safe_name:
       ensure  => $_ensure,
       path    => $path,
       mask    => $mask,

--- a/manifests/system_table.pp
+++ b/manifests/system_table.pp
@@ -64,6 +64,13 @@ define incron::system_table (
 
   $_ensure = $enable ? { true => 'present', default => 'absent' }
 
+  # We need to inform the Puppet parser that we're creating files with the custom type, otherwise Puppet will
+  # purge the /etc/incron.d directory of all files and then the custom type will recreate them resulting in
+  # a non-idempotent loop.
+  file { "/etc/incron.d/${name}":
+    ensure => file,
+  }
+
   if $custom_content {
     incron_system_table { $name:
       ensure  => $_ensure,

--- a/manifests/system_table.pp
+++ b/manifests/system_table.pp
@@ -64,8 +64,9 @@ define incron::system_table (
 
   $_ensure = $enable ? { true => 'present', default => 'absent' }
 
-  # We need to inform the Puppet parser that we're creating files with the custom type, otherwise Puppet will
-  # purge the /etc/incron.d directory of all files and then the custom type will recreate them resulting in
+  # We need to inform the Puppet parser that we're creating files with the
+  # custom type, otherwise Puppet will purge the /etc/incron.d directory of
+  # all files and then the custom type will recreate them resulting in
   # a non-idempotent loop.
   file { "/etc/incron.d/${name}":
     ensure => file,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-incron",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet module for managing incron",
   "license": "Apache-2.0",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -24,7 +24,7 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type:      aio
-  vagrant_memsize: 256
+  vagrant_cpus: 2
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -24,7 +24,7 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type:      aio
-  vagrant_memsize: 256
+  vagrant_cpus: 2
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>

--- a/spec/defines/system_table_spec.rb
+++ b/spec/defines/system_table_spec.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'incron::system_table' do
-  context 'supported operating systems' do
+  context 'with supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
         let(:facts) do
@@ -10,21 +12,27 @@ describe 'incron::system_table' do
 
         context 'with path and command only' do
           let(:title) { 'path_and_command_test' }
-          let(:params) {{
-            :path => '/some/valid/path',
-            :command => '/some/valid/command',
-          }}
+          let(:params) do
+            {
+              :path => '/some/valid/path',
+              :command => '/some/valid/command'
+            }
+          end
 
-          it { is_expected.to create_incron_system_table('path_and_command_test') }
+          it { is_expected.to create_file("/etc/incron.d/#{title}").with_ensure('file') }
+          it { is_expected.to create_incron_system_table(title) }
         end
 
         context 'with custom_content only' do
           let(:title) { 'custom_content_test' }
-          let(:params) {{
-            :custom_content => "totally valid incron content\n"
-          }}
+          let(:params) do
+            {
+              :custom_content => "totally valid incron content\n"
+            }
+          end
 
-          it { is_expected.to create_incron_system_table('custom_content_test') }
+          it { is_expected.to create_file("/etc/incron.d/#{title}").with_ensure('file') }
+          it { is_expected.to create_incron_system_table(title) }
         end
       end
     end

--- a/spec/unit/puppet/provider/incron_system_table/manage_spec.rb
+++ b/spec/unit/puppet/provider/incron_system_table/manage_spec.rb
@@ -16,6 +16,9 @@ describe Puppet::Type.type(:incron_system_table).provider(:manage) do
 
       File.stubs(:read).with('/etc/incron.conf').
         returns("system_table_dir = #{@tmpdir}")
+
+      # Must be mocked, but does't really matter what it returns in these tests
+      Facter.stubs(:value).with(:incrond_version)
     end
 
     after(:each) do


### PR DESCRIPTION
…m type from deleting incron.d files.

I've got very little experience contributing fixes so please bear with me.

This seems like a hackish 'fix' but it does prevent the /etc/init.d/ files from getting deleted/recreated every time puppet runs.